### PR TITLE
Feature/firefox fixes

### DIFF
--- a/src/app/modules/main/main.module.ts
+++ b/src/app/modules/main/main.module.ts
@@ -18,6 +18,8 @@ import {SharedModule} from '../shared/shared.module';
 import {UserAnalyticsModule} from '../user-analytics/user-analytics.module';
 import {HttpClientModule} from '@angular/common/http';
 import {NativeAppModule} from '../native-app/native-app.module';
+import * as localforage from 'localforage';
+import {ClientDetector, ClientNames} from '../shared/services/client-detector.service';
 
 @NgModule({
   imports: [
@@ -44,4 +46,18 @@ import {NativeAppModule} from '../native-app/native-app.module';
   bootstrap: [MainComponent]
 })
 export class MainModule {
+
+  constructor() {
+    /* TODO remove when it is working again
+     * With the latest version of localforage Firefox can not use indexDB
+     * "A mutation operation was attempted on a database that did not allow mutations."
+     * Therefor we have to use localstorage until it is fixed
+     */
+    if (ClientDetector.getClient().name === ClientNames.Firefox) {
+      localforage.config({
+        driver: localforage.LOCALSTORAGE
+      });
+    }
+  }
+
 }

--- a/src/app/modules/shared/pipes/limit-collection-results.pipe.ts
+++ b/src/app/modules/shared/pipes/limit-collection-results.pipe.ts
@@ -14,7 +14,7 @@ export class LimitCollectionresultsPipe implements PipeTransform, OnDestroy {
   }
 
   private _increaseLimitOnBottomReached(ev: MouseWheelEvent) {
-    const srcEl: any = ev.srcElement;
+    const srcEl: any = ev.srcElement || ev.target;
     if (srcEl.scrollTop / (srcEl.scrollHeight - srcEl.offsetHeight) > 0.8) {
       if (this._limit) {
         this._limit += this._orgLimit;

--- a/src/app/modules/shared/pipes/limit-collection-results.pipe.ts
+++ b/src/app/modules/shared/pipes/limit-collection-results.pipe.ts
@@ -1,5 +1,5 @@
-import {ElementRef, EventEmitter, OnDestroy, Pipe, PipeTransform} from '@angular/core';
-import {throttle} from 'underscore';
+import {EventEmitter, OnDestroy, Pipe, PipeTransform} from '@angular/core';
+import {debounce} from 'underscore';
 
 @Pipe({name: 'limitCollectionresults', pure: false})
 export class LimitCollectionresultsPipe implements PipeTransform, OnDestroy {
@@ -9,7 +9,7 @@ export class LimitCollectionresultsPipe implements PipeTransform, OnDestroy {
   private valueChange = new EventEmitter();
 
   constructor() {
-    this._throttledScrollHandler = throttle(this._increaseLimitOnBottomReached.bind(this), 500);
+    this._throttledScrollHandler = debounce(this._increaseLimitOnBottomReached.bind(this), 200);
     document.addEventListener('scroll', this._throttledScrollHandler, true);
   }
 


### PR DESCRIPTION
- Fix #44: use ev.target when srcEl is not exposed
- Use localstorage for firefox as IndexDB does not work with latest localforage version